### PR TITLE
fix: lazily initialize FileTransport to prevent path errors during module load

### DIFF
--- a/src/core/logger.service.ts
+++ b/src/core/logger.service.ts
@@ -55,17 +55,8 @@ export class Logger {
           filePath: this.config.logFilePath,
         });
 
-        try {
-          fileTransport.initialize();
-          this.transports.push(fileTransport);
-        } catch (error) {
-          console.warn(`Failed to initialize file transport: ${error instanceof Error ? error.message : String(error)}`);
-          // Log a warning using the console transport that's already set up
-          this.warn('Failed to initialize file transport', {
-            error: error instanceof Error ? error.message : String(error),
-            filePath: this.config.logFilePath
-          });
-        }
+        // Add the transport; initialization will happen lazily on first log
+        this.transports.push(fileTransport);
       }
     }
   }


### PR DESCRIPTION
Resolves issue where FileTransport initialization using 'path' caused errors during module loading in test environments (e.g., Bun). Implements lazy initialization for the file transport, ensuring 'path' module is available when needed.