### PR TITLE
Feat: Configure package.json exports and add Vitest for validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./core/logger.service": "./dist/core/logger.service.js"
   },
   "scripts": {
     "build": "tsc",
@@ -14,6 +15,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.cjs",
+    "test:vitest": "vitest run test/exports.test.ts",
     "test:watch": "jest --config jest.config.cjs --watch",
     "test:cov": "jest --config jest.config.cjs --coverage",
     "validate": "pnpm lint && pnpm typecheck && pnpm test",

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,49 @@
+// test/exports.test.ts
+import { describe, it, expect } from 'vitest';
+
+// Test the main entry point
+// ESM import for the package itself to test the '.' export.
+// This assumes that '@rollercoaster-dev/rd-logger' resolves to 'dist/index.js'.
+import * as mainApi from '@rollercoaster-dev/rd-logger';
+import { Logger as MainLogger, SensitiveValue as MainSensitiveValue } from '@rollercoaster-dev/rd-logger';
+
+// Test the specific submodule export for 'core/logger.service'.
+// This assumes that '@rollercoaster-dev/rd-logger/core/logger.service' resolves to 'dist/core/logger.service.js'.
+import * as loggerServiceApi from '@rollercoaster-dev/rd-logger/core/logger.service';
+// If 'SensitiveValue' or other specific named exports are expected from 'logger.service.ts',
+// you would import them like this to test their availability:
+// import { SensitiveValue } from '@rollercoaster-dev/rd-logger/core/logger.service';
+
+describe('@rollercoaster-dev/rd-logger public API via exports map', () => {
+  it('should load the main module entry point (dist/index.js) and export key members', () => {
+    expect(mainApi).toBeDefined();
+    // Add more specific assertions here if 'dist/index.js' has named exports.
+    // For example, if 'dist/index.js' exports a 'Logger' class:
+    expect(MainLogger).toBeDefined();
+    expect(typeof MainLogger).toBe('function'); // Assuming Logger is a class
+
+    // Check for SensitiveValue from the main entry point
+    expect(MainSensitiveValue).toBeDefined();
+    // You might also check its type or if it's a class constructor
+    // For example, if SensitiveValue is expected to be a class:
+    // expect(typeof MainSensitiveValue).toBe('function');
+  });
+
+  it('should load the core/logger.service module (dist/core/logger.service.js)', () => {
+    expect(loggerServiceApi).toBeDefined();
+    // Add more specific assertions here based on what 'dist/core/logger.service.js' exports.
+    // For example, if it exports 'LoggerService' class and 'SensitiveValue':
+    // expect(loggerServiceApi.LoggerService).toBeDefined();
+    // expect(loggerServiceApi.SensitiveValue).toBeDefined(); // Or use the direct import above.
+  });
+
+  // Example for testing a specific named export like SensitiveValue from the submodule
+  // (This might be redundant if you only expect SensitiveValue from the main export)
+  // it('should make SensitiveValue available from core/logger.service', () => {
+  //   // To test this, you'd uncomment the specific import for SensitiveValue above:
+  //   // import { SensitiveValue } from '@rollercoaster-dev/rd-logger/core/logger.service';
+  //   expect(SensitiveValue).toBeDefined();
+  //   // You might also check its type or if it's a class constructor
+  //   // expect(typeof SensitiveValue).toBe('function'); // If it's a class or function
+  // });
+});

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -37,13 +37,5 @@ describe('@rollercoaster-dev/rd-logger public API via exports map', () => {
     // expect(loggerServiceApi.SensitiveValue).toBeDefined(); // Or use the direct import above.
   });
 
-  // Example for testing a specific named export like SensitiveValue from the submodule
-  // (This might be redundant if you only expect SensitiveValue from the main export)
-  // it('should make SensitiveValue available from core/logger.service', () => {
-  //   // To test this, you'd uncomment the specific import for SensitiveValue above:
-  //   // import { SensitiveValue } from '@rollercoaster-dev/rd-logger/core/logger.service';
-  //   expect(SensitiveValue).toBeDefined();
-  //   // You might also check its type or if it's a class constructor
-  //   // expect(typeof SensitiveValue).toBe('function'); // If it's a class or function
-  // });
+// (Commented-out test block removed to maintain a clean and focused test file)
 });


### PR DESCRIPTION
This PR addresses module resolution issues by:

1.  Updating the `exports` map in `package.json` to correctly expose the main API (including `Logger` and `SensitiveValue`) and the `core/logger.service` submodule. This allows for more controlled access to the package internals and resolves issues with deep imports.
2.  Adding a new Vitest test suite (`test/exports.test.ts`) to specifically validate these export paths, ensuring that the package can be imported as intended by consumers.
3.  Adding a new npm script (`test:vitest`) to run these specific tests.

These changes ensure that `@rollercoaster-dev/rd-logger` behaves predictably when imported and helps prevent future regressions related to module exports.

Note: `package-lock.json` was not included in this commit due to tool limitations and should be added separately if necessary.