### PR TITLE
chore: Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.3.0](https://github.com/rollercoaster-dev/rd-logger/compare/v0.2.1...v0.3.0) (2025-05-06)
+
+
+### Features
+
+* Configure package.json exports and add vitest for validation ([041436a](https://github.com/rollercoaster-dev/rd-logger/commit/041436ac02244af54ee2cf0b96e3f2915ee68bcf))
+
 ### [0.2.1](https://github.com/rollercoaster-dev/rd-logger/compare/v0.2.0...v0.2.1) (2025-05-03)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rollercoaster-dev/rd-logger",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "description": "A neurodivergent-friendly logger for Rollercoaster.dev projects",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR bumps the version to `0.3.0` and includes updates to `CHANGELOG.md`.